### PR TITLE
Feature/주민 목록 정렬 및 검색 구현

### DIFF
--- a/src/components/searchbar/SearchBar.js
+++ b/src/components/searchbar/SearchBar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 const SearchBarContainer = styled.div`
@@ -81,7 +81,9 @@ const SaveButton = styled.button`
 `;
 
 
-const SearchBar = ({ sort, currentPage, isReversed}) => {
+const SearchBar = ({ sort, search, currentPage, isReversed}) => {
+  const [keyword, setKeyword] = useState('');
+
   // 각 페이지 마다 달라지는 컴포넌트 구성 Drugs, Citizens
   const pageConfig = {
     Drugs: {
@@ -105,8 +107,8 @@ const SearchBar = ({ sort, currentPage, isReversed}) => {
       content: (
       <SearchBarContainer using='citizens'>
         <SearchInputContainer using='citizens'>
-          <SearchInput type="text" placeholder='검색할 주민의 이름을 입력하세요.' />
-          <SearchIcon src="/icons/ic_search.svg" alt="검색" />
+          <SearchInput value={keyword} onChange={(event) => setKeyword(event.target.value)} type="text" placeholder='검색할 주민의 이름을 입력하세요.' />
+          <SearchIcon onClick={() => search(keyword)} src="/icons/ic_search.svg" alt="검색" />
         </SearchInputContainer>
         <SortContainer>
           <SortContainerTag>

--- a/src/components/searchbar/SearchBar.js
+++ b/src/components/searchbar/SearchBar.js
@@ -81,7 +81,7 @@ const SaveButton = styled.button`
 `;
 
 
-const SearchBar = ({ sort, currentPage}) => {
+const SearchBar = ({ sort, currentPage, isReversed}) => {
   // 각 페이지 마다 달라지는 컴포넌트 구성 Drugs, Citizens
   const pageConfig = {
     Drugs: {
@@ -109,7 +109,9 @@ const SearchBar = ({ sort, currentPage}) => {
           <SearchIcon src="/icons/ic_search.svg" alt="검색" />
         </SearchInputContainer>
         <SortContainer>
-          <SortContainerTag>역방향 정렬</SortContainerTag>
+          <SortContainerTag>
+            {isReversed ? '정방향 정렬' : '역방향 정렬'}
+          </SortContainerTag>
           <SortIcon onClick={() => sort()} src="/icons/ic_sort.svg" alt="정렬" />
         </SortContainer>
   

--- a/src/components/searchbar/SearchBar.js
+++ b/src/components/searchbar/SearchBar.js
@@ -81,7 +81,7 @@ const SaveButton = styled.button`
 `;
 
 
-const SearchBar = ({currentPage}) => {
+const SearchBar = ({ sort, currentPage}) => {
   // 각 페이지 마다 달라지는 컴포넌트 구성 Drugs, Citizens
   const pageConfig = {
     Drugs: {
@@ -110,7 +110,7 @@ const SearchBar = ({currentPage}) => {
         </SearchInputContainer>
         <SortContainer>
           <SortContainerTag>역방향 정렬</SortContainerTag>
-          <SortIcon src="/icons/ic_sort.svg" alt="정렬" />
+          <SortIcon onClick={() => sort()} src="/icons/ic_sort.svg" alt="정렬" />
         </SortContainer>
   
         <PlusIcon src="/icons/ic_plus.svg" alt="주민 추가" />

--- a/src/pages/citizens/Citizens.js
+++ b/src/pages/citizens/Citizens.js
@@ -6,16 +6,21 @@ import HeaderComponent from '../../components/header/Header';
 const Citizens = () => {
   const [isReversed, setReverse] = useState(false);
 
-  const [data, setData] = useState([
+  const originalData = [
     { number: 1, name: '홍길동', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
     { number: 2, name: '김글로', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
     { number: 3, name: '김홍탁', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
-  ]);
+  ];
+  const [data, setData] = useState(originalData);
 
   function sortData() {
     setData(prevData => [...prevData].reverse());
     setReverse(!isReversed);
   };
+
+  function search(keyword) {
+    setData(() => [...originalData].filter((item) => item.name.includes(keyword)));
+  }
 
   const columns = [
     { Header: '번호', accessor: 'number' },
@@ -30,7 +35,7 @@ const Citizens = () => {
   return (
     <div>
       <HeaderComponent/>
-      <SearchBar sort={sortData} currentPage={"Citizens"} isReversed={isReversed}/>
+      <SearchBar sort={sortData} search={search} currentPage={"Citizens"} isReversed={isReversed}/>
       <CitizenList columns={columns} data={data} />
     </div>
   );

--- a/src/pages/citizens/Citizens.js
+++ b/src/pages/citizens/Citizens.js
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SearchBar from '../../components/searchbar/SearchBar';
 import CitizenList from '../../components/citizenList/CitizenList';
 import HeaderComponent from '../../components/header/Header';
 
 const Citizens = () => {
+  const [data, setData] = useState([
+    { number: 1, name: '홍길동', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
+    { number: 2, name: '김글로', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
+    { number: 3, name: '김홍탁', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
+  ]);
+
+  function sortData() {
+    setData(prevData => [...prevData].reverse());
+  };
+
   const columns = [
     { Header: '번호', accessor: 'number' },
     { Header: '이름', accessor: 'name' },
@@ -14,15 +24,10 @@ const Citizens = () => {
     { Header: '', accessor: 'action', Cell: () => '조회' },
   ];
 
-  const data = [
-    { number: 1, name: '홍길동', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
-    // TODO(데이터 로드해서 동적으로 CitizenList에 전달하기)
-  ];
-
   return (
     <div>
       <HeaderComponent/>
-      <SearchBar currentPage={"Citizens"}/>
+      <SearchBar sort={sortData} currentPage={"Citizens"}/>
       <CitizenList columns={columns} data={data} />
     </div>
   );

--- a/src/pages/citizens/Citizens.js
+++ b/src/pages/citizens/Citizens.js
@@ -4,6 +4,8 @@ import CitizenList from '../../components/citizenList/CitizenList';
 import HeaderComponent from '../../components/header/Header';
 
 const Citizens = () => {
+  const [isReversed, setReverse] = useState(false);
+
   const [data, setData] = useState([
     { number: 1, name: '홍길동', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
     { number: 2, name: '김글로', address: '서울특별시 종로구 @@', caseHistory: 'No', medication: '아스피린', note: 'None' },
@@ -12,6 +14,7 @@ const Citizens = () => {
 
   function sortData() {
     setData(prevData => [...prevData].reverse());
+    setReverse(!isReversed);
   };
 
   const columns = [
@@ -27,7 +30,7 @@ const Citizens = () => {
   return (
     <div>
       <HeaderComponent/>
-      <SearchBar sort={sortData} currentPage={"Citizens"}/>
+      <SearchBar sort={sortData} currentPage={"Citizens"} isReversed={isReversed}/>
       <CitizenList columns={columns} data={data} />
     </div>
   );


### PR DESCRIPTION
주민 목록 정렬 및 검색 기능을 구현했습니다
- 검색 : 키워드가 포함된 주민의 이름을 기준으로 검색되도록 구현하였습니다.
- 정렬 : 현재는 Dummy 데이터인 주민 목록을 역방향, 정방향 정렬되도록 구현하였습니다.

조교님께서 알려주신 플러그인을 사용하지 않아도 현재로서는 무리가 없기 때문에 useState만 사용하였습니다!

## 스크린샷

### 검색
<img width="498" alt="스크린샷 2024-02-20 오후 7 00 50" src="https://github.com/neulpeum/neulpeum_FrontEnd/assets/56534241/672695bd-e8a3-4c31-8fc2-b9832d0f09f5">

### 정렬
<img width="499" alt="스크린샷 2024-02-20 오후 7 00 36" src="https://github.com/neulpeum/neulpeum_FrontEnd/assets/56534241/f2f0b09d-b04a-4b26-b37f-4e5d5ad55244">
